### PR TITLE
feat: add ability to reverse the horizontal image rotation direction

### DIFF
--- a/src/ReactImageTurntable.tsx
+++ b/src/ReactImageTurntable.tsx
@@ -31,6 +31,7 @@ export const ReactImageTurntable: FC<ReactImageTurntableFullProps> = ({
   movementSensitivity = 20,
   onIndexChange,
   autoRotate = { disabled: false },
+  reverseHorizontal = false,
   ...props
 }) => {
   const { ref, activeImageIndex } = useTurntableState({
@@ -38,6 +39,7 @@ export const ReactImageTurntable: FC<ReactImageTurntableFullProps> = ({
     imagesCount: images.length - 1,
     movementSensitivity,
     autoRotate,
+    reverseHorizontal,
   });
 
   const rootStyle: CSSProperties = {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -4,7 +4,10 @@ import type { ReactImageTurntableProps } from './types';
 
 interface UseTurntableStateProps
   extends Required<
-    Pick<ReactImageTurntableProps, 'initialImageIndex' | 'movementSensitivity' | 'autoRotate'>
+    Pick<
+      ReactImageTurntableProps,
+      'initialImageIndex' | 'movementSensitivity' | 'autoRotate' | 'reverseHorizontal'
+    >
   > {
   /** Number of images starting from zero. */
   imagesCount: number;
@@ -15,6 +18,7 @@ export const useTurntableState = ({
   imagesCount,
   movementSensitivity,
   autoRotate,
+  reverseHorizontal,
 }: UseTurntableStateProps) => {
   const [activeImageIndex, setActiveImageIndex] = useState(initialImageIndex);
   const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
@@ -70,12 +74,20 @@ export const useTurntableState = ({
 
       if (distanceDragged <= -movementSensitivity) {
         prevDragPosition = prevDragPosition + movementSensitivity;
-        incrementActiveIndex();
+        if (!reverseHorizontal) {
+          incrementActiveIndex();
+        } else {
+          decrementActiveIndex();
+        }
       }
 
       if (distanceDragged >= movementSensitivity) {
         prevDragPosition = prevDragPosition - movementSensitivity;
-        decrementActiveIndex();
+        if (!reverseHorizontal) {
+          decrementActiveIndex();
+        } else {
+          incrementActiveIndex();
+        }
       }
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export interface ReactImageTurntableProps {
     /** The speed (in ms) at which the turntable rotates. */
     interval?: number;
   };
+  /** In case you want to change the direction on dragging left/right. */
+  reverseHorizontal?: boolean;
 }
 
 /** Base props *and* all available HTML element props. */


### PR DESCRIPTION
# Motivation
Some image just don't start from a certain direction. This caused dragging image doesn't feel natural. I could rename the image to a certain direction of course, but I feel we could add improvement to the library instead!

Result:

https://github.com/user-attachments/assets/72d159d2-51cd-457c-8030-82aae282d053